### PR TITLE
Reload job config when adding or deleting promotions.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,12 @@
 			<version>1.0-groovy-2.3</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>cglib</groupId>
+			<artifactId>cglib-nodep</artifactId>
+			<version>3.1</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 	<build>
 		<plugins>

--- a/src/test/java/org/jenkinsci/plugins/jobdsl/promotions/PromotionsExtensionPointSpec.groovy
+++ b/src/test/java/org/jenkinsci/plugins/jobdsl/promotions/PromotionsExtensionPointSpec.groovy
@@ -64,7 +64,9 @@ class PromotionsExtensionPointSpec extends Specification {
                 }
             }
         }, dslEnvironment)
-        FreeStyleProject item = new FreeStyleProject(Jenkins.getInstance(), 'freestyle')
+        FreeStyleProject item = Spy(FreeStyleProject, constructorArgs: [Jenkins.getInstance(), 'freestyle']) {
+            1 * doReload() >> {}
+        }
         extensionPoint.notifyItemCreated(item, dslEnvironment)
 
         then:


### PR DESCRIPTION
When generating jobs with promtions, this plugin correctly creates and places the config.xml for each promotion in the proper folder and adds the correct nodes to the parent job config, but it generates the promotions _after_ the parent job has been created (notice the method name is "notifyItemCreated").

This causes a race condition where jenkins (most of the time) doesn't actually load the promotions, and needs to be restarted to pick them up.

This change reloads the parent job if any promotions are added, updated, or deleted.
